### PR TITLE
Allow passing of template folder path as a string argument

### DIFF
--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -33,9 +33,8 @@ module.exports = function(grunt) {
 
             var template = grunt.file.read(filepath);
             
-            if (Array.isArray(options.paths) && options.paths.length ||
-                typeof options.paths == 'string') {
-              nunjucks.configure(options.paths);
+            if (options.paths) {
+                nunjucks.configure(options.paths);
             }
             
             var compiledHtml = nunjucks.renderString(template, data);


### PR DESCRIPTION
Currently, it has to be passed as an array to work:

``` js
nunjucks: {
  options: {
     paths: ['templates'],
     data: grunt.file.readJSON('results.json')
   }, 
   ...
}
```
