### PR TITLE
added custom syntax option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,35 @@ nunjucks: {
 
 You could specify root path for your templates, `paths` would be set for [nunjucks' configure](http://mozilla.github.io/nunjucks/api#configure)
 
+
+### Customizing Syntax
+
+If you want different tokens than {{ and the rest for variables, blocks, and comments, you can specify different tokens as the tags option:
+
+nunjucks: {
+  options: {
+    tags: {
+      blockStart: '<%',
+      blockEnd: '%>',
+      variableStart: '<$',
+      variableEnd: '$>',
+      commentStart: '<#',
+      commentEnd: '#>'
+    },
+    data: grunt.file.readJSON('data.json')
+  },
+  render: {
+    files: [
+       {
+          expand: true,
+          cwd: "bundles/",
+          src: "*.html",
+          dest: "build/",
+          ext: ".html"
+       }
+    ]
+  }
+```
+
+
 Nice!

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ You could specify root path for your templates, `paths` would be set for [nunjuc
 
 If you want different tokens than {{ and the rest for variables, blocks, and comments, you can specify different tokens as the tags option:
 
+```javascipt
 nunjucks: {
   options: {
     tags: {

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -36,7 +36,12 @@ module.exports = function(grunt) {
             if (options.paths) {
                 nunjucks.configure(options.paths);
             }
-            
+            if(options.tags){
+                var basepath = options.paths || "";
+                nunjucks.configure(basepath, {
+                  tags: options.tags
+                });
+            }
             var compiledHtml = nunjucks.renderString(template, data);
 
             grunt.file.write(f.dest, compiledHtml);


### PR DESCRIPTION
## Custom syntax option

Added an option that makes it possible to use a custom syntax, I also updated the readme

Usage :

```javascipt
nunjucks: {
  options: {
    tags: {
      blockStart: '<%',
      blockEnd: '%>',
      variableStart: '<$',
      variableEnd: '$>',
      commentStart: '<#',
      commentEnd: '#>'
    },
    data: grunt.file.readJSON('data.json')
  },
  render: {
    files: [
       {
          expand: true,
          cwd: "bundles/",
          src: "*.html",
          dest: "build/",
          ext: ".html"
       }
    ]
  }