### PR TITLE
Moved nunjucks and async to dependencies section

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
   "engines": {
     "node": ">= 0.8.0"
   },
+  "dependencies": {
+    "nunjucks": "^1.1.0",
+    "async": "^0.9.0"
+  },
   "devDependencies": {
-    "nunjucks": "~1.1.0",
-    "grunt-jscs": "~1.5.0",
-    "expect.js": "~0.3.0",
-    "async": "~0.9.0"
+    "grunt-jscs": "^1.5.0",
+    "expect.js": "^0.3.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.1"


### PR DESCRIPTION
Requested modules should be listed in `dependencies` section of package json, othervise module will fail with `>> Error: Cannot find module 'async'`

P.S. also replaced tildes with carets since its default behavior for npm --save since version 1.4.3