### PR TITLE
fix non-relative path for leaking vars test

### DIFF
--- a/tests/leaking-vars/input1.html
+++ b/tests/leaking-vars/input1.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "tests/leaking-vars/base.html" %}
 
 {% set testVar = "testVar from page1" %}
 {% set testVar2 = "testVar2 from page1" %}

--- a/tests/leaking-vars/input2.html
+++ b/tests/leaking-vars/input2.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "tests/leaking-vars/base.html" %}
 
 {% set testVar = "testVar from page2" %}
 


### PR DESCRIPTION
Eh, one more thing that I've missed, for #9.

Btw, according to nunjucks [1.3.0](https://github.com/mozilla/nunjucks/releases/tag/v1.3.0) release, relative paths should work, like:

``` twig
{% extends "./leaking-vars/base.html" %}
```

or

``` twig
{% extends "../leaking-vars/base.html" %}
```

But it newer worked for me.

A bit more [info](https://github.com/mozilla/nunjucks/pull/349)

Though, I assume it's probably nunjucks-related issue.