### PR TITLE
export `nunjucks` variable during call of `configureEnvironment`

### DIFF
--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
         var env = nunjucks.configure(basePath, envOptions);
 
         if (typeof options.configureEnvironment === 'function') {
-            options.configureEnvironment.call(this, env);
+            options.configureEnvironment.call(this, env, nunjucks);
         }
 
         async.each(this.files, function(f, done) {


### PR DESCRIPTION
Sometimes you need access to `nunjucks` during configuration of environment.

For example, if you need to pre-render some string in custom filter or extension.