### PR TITLE
Configurable autoescaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,29 @@ nunjucks: {
 
 You could specify root path for your templates, `paths` would be set for [nunjucks' configure](http://mozilla.github.io/nunjucks/api#configure)
 
+### Autoescaping
+
+You can turn off Nunjucks' [autoescaping](https://mozilla.github.io/nunjucks/templating.html#autoescaping) which is enabled by default:
+
+```js
+nunjucks: {
+  options: {
+    autoescape: false
+  },
+  render: {
+    files: [
+       {
+          expand: true,
+          cwd: "bundles/",
+          src: "*.html",
+          dest: "build/",
+          ext: ".html"
+       }
+    ]
+  }
+}
+```
+
 ### Customizing Syntax
 
 If you want different tokens than {{ and the rest for variables, blocks, and comments, you can specify different tokens as the tags option:

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -21,10 +21,10 @@ module.exports = function(grunt) {
             grunt.log.warn('Template`s data is empty. Guess you forget to specify data option');
         }
 
-        var envOptions = { watch: false };
-        if (typeof options.autoescape === 'boolean') {
-            envOptions.autoescape = options.autoescape;
-        }
+        var envOptions = {
+            watch: false,
+            autoescape: options.autoescape || undefined
+        };
         if (options.tags) {
             envOptions.tags = options.tags;
         }

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -22,6 +22,9 @@ module.exports = function(grunt) {
         }
 
         var envOptions = { watch: false };
+        if (typeof options.autoescape === 'boolean') {
+            envOptions.autoescape = options.autoescape;
+        }
         if (options.tags) {
             envOptions.tags = options.tags;
         }


### PR DESCRIPTION
In Nunjucks 2.0 autoescaping is on by default.

Some like it ~~hot~~ to be switched off.

Not sure about `typeof` check in that PR... maybe you have better ideas.

Thanks