### PR TITLE
ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "compile"
   ],
   "engines": {
-    "node": "^0.8.0"
+    "node": "^0.12.0"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "compile"
   ],
   "engines": {
-    "node": ">= 0.8.0"
+    "node": "^0.8.0"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "async": "^1.4.2",
     "nunjucks": "^2.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "compile"
   ],
   "engines": {
-    "node": "^0.12.0"
+    "node": "^4.0.0"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
+    "chalk": "^1.1.1",
     "nunjucks": "^2.1.0"
   },
   "devDependencies": {

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -14,7 +14,7 @@ var path = require('path');
 
 module.exports = function(grunt) {
 
-    grunt.registerMultiTask('nunjucks', 'Renders nunjucks` template to HTML', function() {
+    grunt.registerMultiTask('nunjucks', 'Renders nunjucks\' template to HTML', function() {
         // Declare async task
         var completeTask = this.async();
 
@@ -31,7 +31,7 @@ module.exports = function(grunt) {
 
         // Warn in case of undefined data
         if (!options.data) {
-            grunt.log.error('Template`s data is empty. Guess you forget to specify data option');
+            grunt.log.error('Template\'s data is empty. Guess you forget to specify data option');
         }
 
         // Construct options for Nunjucks' environment

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -154,7 +154,7 @@ module.exports = function (grunt) {
         .then(success => {
             // Log number of processed templates
             let logType            = (countCompiled === totalFiles) ? 'ok' : 'error'
-            let countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red'
+            let countCompiledColor = (logType === 'ok') ? 'green' : 'red'
             grunt.log[logType](`${chalk[countCompiledColor](countCompiled)}/${chalk.cyan(totalFiles)} ${grunt.util.pluralize(totalFiles, 'file/files')} compiled.`)
         })
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -15,54 +15,74 @@ var path = require('path');
 module.exports = function(grunt) {
 
     grunt.registerMultiTask('nunjucks', 'Renders nunjucks` template to HTML', function() {
+        // Declare async task
         var completeTask = this.async();
 
+        // Get options
         var options = this.options();
 
+        // Finish task if no files specified
         if (!this.files.length) {
             grunt.log.error('No files specified.');
 
+            // Finish task — nothing we can do without specified files
             return completeTask()
         }
 
+        // Warn in case of undefined data
         if (!options.data) {
             grunt.log.error('Template`s data is empty. Guess you forget to specify data option');
         }
 
+        // Construct options for Nunjucks' environment
         var envOptions = { watch: false };
         if (options.tags) {
             envOptions.tags = options.tags;
         }
 
+        // Get path for Nunjucks' environment
         var basePath = options.paths || '';
+
+        // Arm Nunjucks
         var env = nunjucks.configure(basePath, envOptions);
 
+        // Pass configuration to Nunjucks if specified
         if (typeof options.configureEnvironment === 'function') {
             options.configureEnvironment.call(this, env, nunjucks);
         }
 
+        // Get number of files
         var totalFiles = this.files.length;
+        // Start counter for number of compiled files
         var countCompiled = 0;
 
+        // Iterate over all files' groups
         this.files.forEach(function(file) {
+            // Set destination
             var filedest = file.dest;
 
+            // Check whether there are any source files
             if (!file.src.length) {
                 grunt.log.error('No source files specified for ' + chalk.cyan(filedest));
 
+                // Skip to next file — nothing we can do without specified source files
                 return
             }
 
+            // Iterate over files' sources
             file.src.forEach(function(src) {
+                // Сheck whether source file exists
                 if (!grunt.file.exists(src)) {
                     grunt.log.error('Source file ' + chalk.cyan(src) + ' for ' + chalk.cyan(filedest) + ' not found.');
 
+                    // Skip to next source file — nothing we can do with non-existing file
                     return
                 }
 
+                // Construct absolute path to file for Nunjucks
                 var filepath = path.join(process.cwd(), src);
 
-                // We need to clone the data
+                // Clone data
                 var data = {};
                 for (var i in options.data) {
                     if (options.data.hasOwnProperty(i)) {
@@ -70,20 +90,28 @@ module.exports = function(grunt) {
                     }
                 }
 
+                // Preprocess data
                 if (typeof options.preprocessData === 'function') {
                     data = options.preprocessData.call(file, data);
                 }
 
+                // Asynchronously render templates with configurated Nunjucks environment
+                // and write to destination
                 env.render(filepath, data, function(err, res) {
+                    // Catch errors, warn
                     if (err) {
                         grunt.log.error(err);
                         grunt.fail.warn('Failed to compile one of the sources.');
                         grunt.log.writeln();
 
+                        // Prevent writing of failed to compile file, skip to next file
                         return
                     }
+
+                    // Write rendered template to destination
                     grunt.file.write(filedest, res);
 
+                    // Debug process
                     grunt.verbose.ok('File ' + chalk.cyan(filedest) + ' created.');
                     grunt.verbose.writeln();
                 });
@@ -92,10 +120,12 @@ module.exports = function(grunt) {
             });
         });
 
+        // Log number of processed templates
         var logType            = (countCompiled === totalFiles) ? 'ok' : 'error';
         var countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red';
         grunt.log[logType](chalk[countCompiledColor](countCompiled) + '/' + chalk.cyan(totalFiles) + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.');
 
+        // Finish async task
         completeTask();
     });
 };

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -9,8 +9,8 @@
 'use strict'
 
 const nunjucks = require('nunjucks')
-const chalk = require('chalk')
-const path = require('path')
+const chalk    = require('chalk')
+const path     = require('path')
 
 module.exports = function (grunt) {
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -21,15 +21,15 @@ module.exports = function(grunt) {
         // Get options and set defaults
         // @note We're using `undefined` to fallback to Nunjucks' default settings
         var options = this.options({
-            data                 : false,
+            paths                : '',
             autoescape           : undefined,
             throwOnUndefined     : undefined,
             trimBlocks           : undefined,
             lstripBlocks         : undefined,
             noCache              : undefined,
             tags                 : undefined,
-            paths                : '',
             configureEnvironment : false,
+            data                 : false,
             preprocessData       : false
         });
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -67,6 +67,7 @@ module.exports = function (grunt) {
         // Start counter for number of compiled files
         let countCompiled = 0
 
+        // Run compilation asynchronously, wait for finish, then print results and complete task
         new Promise((resolve, reject) => {
 
             // Iterate over all files' groups

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -19,10 +19,15 @@ module.exports = function(grunt) {
         var completeTask = this.async();
 
         // Get options and set defaults
+        // @note We're using `undefined` to fallback to Nunjucks' default settings
         var options = this.options({
             data                 : false,
-            autoescape           : undefined, // avoid overriding of Nunjucks' default preference
-            tags                 : false,
+            autoescape           : undefined,
+            throwOnUndefined     : undefined,
+            trimBlocks           : undefined,
+            lstripBlocks         : undefined,
+            noCache              : undefined,
+            tags                 : undefined,
             paths                : '',
             configureEnvironment : false,
             preprocessData       : false
@@ -43,9 +48,13 @@ module.exports = function(grunt) {
 
         // Arm Nunjucks
         var env = nunjucks.configure(options.paths, {
-            watch: false,
-            autoescape: options.autoescape,
-            tags: options.tags
+            watch            : false,
+            autoescape       : options.autoescape,
+            throwOnUndefined : options.throwOnUndefined,
+            trimBlocks       : options.trimBlocks,
+            lstripBlocks     : options.lstripBlocks,
+            noCache          : options.noCache,
+            tags             : options.tags
         });
 
         // Pass configuration to Nunjucks if specified

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -21,6 +21,7 @@ module.exports = function(grunt) {
         // Get options and set defaults
         var options = this.options({
             data                 : false,
+            autoescape           : undefined, // avoid overriding of Nunjucks' default preference
             tags                 : false,
             paths                : '',
             configureEnvironment : false,
@@ -43,6 +44,7 @@ module.exports = function(grunt) {
         // Arm Nunjucks
         var env = nunjucks.configure(options.paths, {
             watch: false,
+            autoescape: options.autoescape,
             tags: options.tags
         });
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -8,19 +8,19 @@
 
 'use strict'
 
-var nunjucks = require('nunjucks')
-var chalk = require('chalk')
-var path = require('path')
+const nunjucks = require('nunjucks')
+const chalk = require('chalk')
+const path = require('path')
 
 module.exports = function (grunt) {
 
     grunt.registerMultiTask('nunjucks', 'Renders nunjucks\' template to HTML', function () {
         // Declare async task
-        var completeTask = this.async()
+        const completeTask = this.async()
 
         // Get options and set defaults
         // @note We're using `undefined` to fallback to Nunjucks' default settings
-        var options = this.options({
+        const options = this.options({
             paths                : '',
             autoescape           : undefined,
             throwOnUndefined     : undefined,
@@ -47,7 +47,7 @@ module.exports = function (grunt) {
         }
 
         // Arm Nunjucks
-        var env = nunjucks.configure(options.paths, {
+        const env = nunjucks.configure(options.paths, {
             watch            : false,
             autoescape       : options.autoescape,
             throwOnUndefined : options.throwOnUndefined,
@@ -63,16 +63,16 @@ module.exports = function (grunt) {
         }
 
         // Get number of files
-        var totalFiles = this.files.length
+        const totalFiles = this.files.length
         // Start counter for number of compiled files
-        var countCompiled = 0
+        let countCompiled = 0
 
         new Promise((resolve, reject) => {
 
             // Iterate over all files' groups
             this.files.forEach(file => {
                 // Set destination
-                var filedest = file.dest
+                let filedest = file.dest
 
                 // Check whether there are any source files
                 if (!file.src.length) {
@@ -93,13 +93,13 @@ module.exports = function (grunt) {
                     }
 
                     // Construct absolute path to file for Nunjucks
-                    var filepath = path.join(process.cwd(), src)
+                    let filepath = path.join(process.cwd(), src)
 
-                    var data = {}
+                    let data = {}
                     // Work with data only there is any data
                     if (options.data) {
                         // Clone data
-                        for (var i in options.data) {
+                        for (let i in options.data) {
                             if (options.data.hasOwnProperty(i)) {
                                 data[i] = options.data[i]
                             }
@@ -152,8 +152,8 @@ module.exports = function (grunt) {
         // Log number of processed templates
         .then(() => {
             // Log number of processed templates
-            var logType            = (countCompiled === totalFiles) ? 'ok' : 'error'
-            var countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red'
+            let logType            = (countCompiled === totalFiles) ? 'ok' : 'error'
+            let countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red'
             grunt.log[logType](chalk[countCompiledColor](countCompiled) + '/' + chalk.cyan(totalFiles) + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.')
         })
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -85,14 +85,6 @@ module.exports = function (grunt) {
 
                 // Iterate over files' sources
                 file.src.forEach(src => {
-                    // Сheck whether source file exists
-                    if (!grunt.file.exists(src)) {
-                        grunt.log.error(`Source file ${chalk.cyan(src)} for ${chalk.cyan(filedest)} not found.`)
-
-                        // Skip to next source file — nothing we can do with non-existing file
-                        return reject('Some source files were not found.')
-                    }
-
                     // Construct absolute path to file for Nunjucks
                     let filepath = path.join(process.cwd(), src)
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -8,7 +8,6 @@
 
 var nunjucks = require('nunjucks');
 var path = require('path');
-var async = require('async');
 
 module.exports = function(grunt) {
     'use strict';
@@ -33,38 +32,35 @@ module.exports = function(grunt) {
             options.configureEnvironment.call(this, env, nunjucks);
         }
 
-        async.each(this.files, function(f, done) {
-            var filepath = path.join(process.cwd(), f.src[0]);
+        this.files.forEach(function(file) {
+            var filedest = file.dest;
 
-            // We need to clone the data
-            var data = {};
-            for (var i in options.data) {
-                if (options.data.hasOwnProperty(i)) {
-                    data[i] = options.data[i];
+            file.src.forEach(function(src) {
+                var filepath = path.join(process.cwd(), src);
+
+                // We need to clone the data
+                var data = {};
+                for (var i in options.data) {
+                    if (options.data.hasOwnProperty(i)) {
+                        data[i] = options.data[i];
+                    }
                 }
-            }
 
-            if (typeof options.preprocessData === 'function') {
-                data = options.preprocessData.call(f, data);
-            }
-
-            env.render(filepath, data, function(err, res) {
-                if (err) {
-                    grunt.log.error(err);
-                    grunt.fail.warn('Failed to compile one of the sources.');
-                    return done();
+                if (typeof options.preprocessData === 'function') {
+                    data = options.preprocessData.call(file, data);
                 }
-                grunt.file.write(f.dest, res);
-                grunt.log.writeln('File "' + f.dest + '" created.');
-                done();
+
+                env.render(filepath, data, function(err, res) {
+                    if (err) {
+                        grunt.log.error(err);
+                        grunt.fail.warn('Failed to compile one of the sources.');
+                    }
+                    grunt.file.write(filedest, res);
+                    grunt.log.writeln('File "' + filedest + '" created.');
+                });
             });
-
-        }, function(err) {
-            if (err) {
-                grunt.log.error(err);
-                grunt.fail.warn('Something went wrong.');
-            }
-            completeTask();
         });
+
+        completeTask();
     });
 };

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -62,7 +62,7 @@ module.exports = function (grunt) {
         let countCompiled = 0
 
         // Run compilation asynchronously, wait for finish, then print results and complete task
-        new Promise((resolve, reject) => {
+        const task = new Promise((resolve, reject) => {
 
             // Iterate over all files' groups
             this.files.forEach(file => {

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -50,7 +50,7 @@ module.exports = function(grunt) {
 
             file.src.forEach(function(src) {
                 if (!grunt.file.exists(src)) {
-                    grunt.log.error('Source file ' + src ' for ' + filedest + ' not found.');
+                    grunt.log.error('Source file ' + src + ' for ' + filedest + ' not found.');
 
                     return
                 }

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -82,18 +82,23 @@ module.exports = function(grunt) {
                 // Construct absolute path to file for Nunjucks
                 var filepath = path.join(process.cwd(), src);
 
-                // Clone data
                 var data = {};
-                for (var i in options.data) {
-                    if (options.data.hasOwnProperty(i)) {
-                        data[i] = options.data[i];
+                // Work with data only there is any data
+                if (options.data) {
+                    // Clone data
+                    for (var i in options.data) {
+                        if (options.data.hasOwnProperty(i)) {
+                            data[i] = options.data[i];
+                        }
+                    }
+
+                    // Preprocess data
+                    if (typeof options.preprocessData === 'function') {
+                        data = options.preprocessData.call(file, data);
                     }
                 }
 
-                // Preprocess data
-                if (typeof options.preprocessData === 'function') {
-                    data = options.preprocessData.call(file, data);
-                }
+
 
                 // Asynchronously render templates with configurated Nunjucks environment
                 // and write to destination

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -14,7 +14,7 @@ const path     = require('path')
 
 module.exports = function (grunt) {
 
-    grunt.registerMultiTask('nunjucks', 'Renders nunjucks\' template to HTML', function () {
+    grunt.registerMultiTask('nunjucks', `Renders Nunjucks' templates to HTML`, function () {
         // Declare async task
         const completeTask = this.async()
 
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
 
         // Warn in case of undefined data
         if (!options.data) {
-            grunt.log.error('Template\'s data is empty. Guess you forget to specify data option')
+            grunt.log.error(`Template's data is empty. Guess you've forget to specify data option`)
         }
 
         // Arm Nunjucks
@@ -77,7 +77,7 @@ module.exports = function (grunt) {
 
                 // Check whether there are any source files
                 if (!file.src.length) {
-                    grunt.log.error('No source files specified for ' + chalk.cyan(filedest))
+                    grunt.log.error(`No source files specified for ${chalk.cyan(filedest)}`)
 
                     // Skip to next file — nothing we can do without specified source files
                     return reject('For some destinations were not specified source files')
@@ -87,7 +87,7 @@ module.exports = function (grunt) {
                 file.src.forEach(src => {
                     // Сheck whether source file exists
                     if (!grunt.file.exists(src)) {
-                        grunt.log.error('Source file ' + chalk.cyan(src) + ' for ' + chalk.cyan(filedest) + ' not found.')
+                        grunt.log.error(`Source file ${chalk.cyan(src)} for ${chalk.cyan(filedest)} not found`)
 
                         // Skip to next source file — nothing we can do with non-existing file
                         return reject('Some source files were not found')
@@ -129,7 +129,7 @@ module.exports = function (grunt) {
                         grunt.file.write(filedest, res)
 
                         // Debug process
-                        grunt.verbose.ok('File ' + chalk.cyan(filedest) + ' created.')
+                        grunt.verbose.ok(`File ${chalk.cyan(filedest)} created.`)
                         grunt.verbose.writeln()
 
                         countCompiled++
@@ -155,7 +155,7 @@ module.exports = function (grunt) {
             // Log number of processed templates
             let logType            = (countCompiled === totalFiles) ? 'ok' : 'error'
             let countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red'
-            grunt.log[logType](chalk[countCompiledColor](countCompiled) + '/' + chalk.cyan(totalFiles) + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.')
+            grunt.log[logType](`${chalk[countCompiledColor](countCompiled)}/${chalk.cyan(totalFiles)} ${grunt.util.pluralize(totalFiles, 'file/files')} compiled.`)
         })
 
         // Finish async task

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -97,7 +97,7 @@ module.exports = function (grunt) {
                     let filepath = path.join(process.cwd(), src)
 
                     let data = {}
-                    // Work with data only there is any data
+                    // Work with data only if there is any data
                     if (options.data) {
                         // Clone data
                         for (let i in options.data) {

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -109,8 +109,6 @@ module.exports = function(grunt) {
                     }
                 }
 
-
-
                 // Asynchronously render templates with configurated Nunjucks environment
                 // and write to destination
                 env.render(filepath, data, function(err, res) {

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -93,7 +93,7 @@ module.exports = function(grunt) {
 
         var logType            = (countCompiled === totalFiles) ? 'ok' : 'error';
         var countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red';
-        grunt.log[logType](chalk[countCompiledColor](countCompiled) + '/' + chalk.cyan(totalFiles) + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.')
+        grunt.log[logType](chalk[countCompiledColor](countCompiled) + '/' + chalk.cyan(totalFiles) + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.');
 
         completeTask();
     });

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -91,7 +91,9 @@ module.exports = function(grunt) {
             });
         });
 
-        grunt.log.ok(countCompiled + '/' + totalFiles + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.')
+        var logType            = (countCompiled === totalFiles) ? 'ok' : 'error';
+        var countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red';
+        grunt.log[logType](chalk[countCompiledColor](countCompiled) + '/' + chalk.cyan(totalFiles) + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.')
 
         completeTask();
     });

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -83,7 +83,7 @@ module.exports = function(grunt) {
                     }
                     grunt.file.write(filedest, res);
 
-                    grunt.verbose.ok('File "' + chalk.cyan(filedest) + '" created.');
+                    grunt.verbose.ok('File ' + chalk.cyan(filedest) + ' created.');
                     grunt.verbose.writeln();
                 });
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -79,7 +79,7 @@ module.exports = function (grunt) {
                     grunt.log.error('No source files specified for ' + chalk.cyan(filedest))
 
                     // Skip to next file — nothing we can do without specified source files
-                    return
+                    return reject('For some destinations were not specified source files')
                 }
 
                 // Iterate over files' sources
@@ -89,7 +89,7 @@ module.exports = function (grunt) {
                         grunt.log.error('Source file ' + chalk.cyan(src) + ' for ' + chalk.cyan(filedest) + ' not found.')
 
                         // Skip to next source file — nothing we can do with non-existing file
-                        return
+                        return reject('Some source files were not found')
                     }
 
                     // Construct absolute path to file for Nunjucks
@@ -121,7 +121,7 @@ module.exports = function (grunt) {
                             grunt.log.writeln()
 
                             // Prevent writing of failed to compile file, skip to next file
-                            return
+                            return reject('Failed to compile some source files')
                         }
 
                         // Write rendered template to destination

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -73,6 +73,8 @@ module.exports = function(grunt) {
                     if (err) {
                         grunt.log.error(err);
                         grunt.fail.warn('Failed to compile one of the sources.');
+
+                        return
                     }
                     grunt.file.write(filedest, res);
                     grunt.log.writeln('File "' + filedest + '" created.');

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
         var completeTask = this.async();
 
         if (!options.data) {
-            grunt.log.warn('Template`s data is empty. Guess you forget to specify data option');
+            grunt.log.error('Template`s data is empty. Guess you forget to specify data option');
         }
 
         var envOptions = { watch: false };

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -73,6 +73,7 @@ module.exports = function(grunt) {
                     if (err) {
                         grunt.log.error(err);
                         grunt.fail.warn('Failed to compile one of the sources.');
+                        grunt.log.writeln();
 
                         return
                     }

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -6,11 +6,12 @@
  * Licensed under the MIT license.
  */
 
+'use strict';
+
 var nunjucks = require('nunjucks');
 var path = require('path');
 
 module.exports = function(grunt) {
-    'use strict';
 
     grunt.registerMultiTask('nunjucks', 'Renders nunjucks` template to HTML', function() {
         var options = this.options();

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -89,19 +89,16 @@ module.exports = function (grunt) {
                     let filepath = path.join(process.cwd(), src)
 
                     let data = {}
-                    // Work with data only if there is any data
-                    if (options.data) {
-                        // Clone data
-                        for (let i in options.data) {
-                            if (options.data.hasOwnProperty(i)) {
-                                data[i] = options.data[i]
-                            }
+                    // Clone data
+                    for (let i in options.data) {
+                        if (options.data.hasOwnProperty(i)) {
+                            data[i] = options.data[i]
                         }
+                    }
 
-                        // Preprocess data
-                        if (typeof options.preprocessData === 'function') {
-                            data = options.preprocessData.call(file, data)
-                        }
+                    // Preprocess data
+                    if (options.data && typeof options.preprocessData === 'function') {
+                        data = options.preprocessData.call(file, data)
                     }
 
                     // Asynchronously render templates with configurated Nunjucks environment

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -15,8 +15,9 @@ var path = require('path');
 module.exports = function(grunt) {
 
     grunt.registerMultiTask('nunjucks', 'Renders nunjucks` template to HTML', function() {
-        var options = this.options();
         var completeTask = this.async();
+
+        var options = this.options();
 
         if (!this.files.length) {
             grunt.log.error('No files specified.');

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -78,7 +78,9 @@ module.exports = function(grunt) {
                         return
                     }
                     grunt.file.write(filedest, res);
-                    grunt.log.writeln('File "' + filedest + '" created.');
+
+                    grunt.verbose.ok('File "' + filedest + '" created.');
+                    grunt.verbose.writeln();
                 });
             });
         });

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -117,7 +117,7 @@ module.exports = function(grunt) {
                     // Catch errors, warn
                     if (err) {
                         grunt.log.error(err);
-                        grunt.fail.warn('Failed to compile one of the sources.');
+                        grunt.fail.warn('Failed to compile one of the source files.');
                         grunt.log.writeln();
 
                         // Prevent writing of failed to compile file, skip to next file

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -6,17 +6,17 @@
  * Licensed under the MIT license.
  */
 
-'use strict';
+'use strict'
 
-var nunjucks = require('nunjucks');
-var chalk = require('chalk');
-var path = require('path');
+var nunjucks = require('nunjucks')
+var chalk = require('chalk')
+var path = require('path')
 
 module.exports = function(grunt) {
 
     grunt.registerMultiTask('nunjucks', 'Renders nunjucks\' template to HTML', function() {
         // Declare async task
-        var completeTask = this.async();
+        var completeTask = this.async()
 
         // Get options and set defaults
         // @note We're using `undefined` to fallback to Nunjucks' default settings
@@ -31,11 +31,11 @@ module.exports = function(grunt) {
             configureEnvironment : false,
             data                 : false,
             preprocessData       : false
-        });
+        })
 
         // Finish task if no files specified
         if (!this.files.length) {
-            grunt.log.error('No files specified.');
+            grunt.log.error('No files specified.')
 
             // Finish task — nothing we can do without specified files
             return completeTask()
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
 
         // Warn in case of undefined data
         if (!options.data) {
-            grunt.log.error('Template\'s data is empty. Guess you forget to specify data option');
+            grunt.log.error('Template\'s data is empty. Guess you forget to specify data option')
         }
 
         // Arm Nunjucks
@@ -55,26 +55,26 @@ module.exports = function(grunt) {
             lstripBlocks     : options.lstripBlocks,
             noCache          : options.noCache,
             tags             : options.tags
-        });
+        })
 
         // Pass configuration to Nunjucks if specified
         if (typeof options.configureEnvironment === 'function') {
-            options.configureEnvironment.call(this, env, nunjucks);
+            options.configureEnvironment.call(this, env, nunjucks)
         }
 
         // Get number of files
-        var totalFiles = this.files.length;
+        var totalFiles = this.files.length
         // Start counter for number of compiled files
-        var countCompiled = 0;
+        var countCompiled = 0
 
         // Iterate over all files' groups
         this.files.forEach(function(file) {
             // Set destination
-            var filedest = file.dest;
+            var filedest = file.dest
 
             // Check whether there are any source files
             if (!file.src.length) {
-                grunt.log.error('No source files specified for ' + chalk.cyan(filedest));
+                grunt.log.error('No source files specified for ' + chalk.cyan(filedest))
 
                 // Skip to next file — nothing we can do without specified source files
                 return
@@ -84,28 +84,28 @@ module.exports = function(grunt) {
             file.src.forEach(function(src) {
                 // Сheck whether source file exists
                 if (!grunt.file.exists(src)) {
-                    grunt.log.error('Source file ' + chalk.cyan(src) + ' for ' + chalk.cyan(filedest) + ' not found.');
+                    grunt.log.error('Source file ' + chalk.cyan(src) + ' for ' + chalk.cyan(filedest) + ' not found.')
 
                     // Skip to next source file — nothing we can do with non-existing file
                     return
                 }
 
                 // Construct absolute path to file for Nunjucks
-                var filepath = path.join(process.cwd(), src);
+                var filepath = path.join(process.cwd(), src)
 
-                var data = {};
+                var data = {}
                 // Work with data only there is any data
                 if (options.data) {
                     // Clone data
                     for (var i in options.data) {
                         if (options.data.hasOwnProperty(i)) {
-                            data[i] = options.data[i];
+                            data[i] = options.data[i]
                         }
                     }
 
                     // Preprocess data
                     if (typeof options.preprocessData === 'function') {
-                        data = options.preprocessData.call(file, data);
+                        data = options.preprocessData.call(file, data)
                     }
                 }
 
@@ -114,32 +114,32 @@ module.exports = function(grunt) {
                 env.render(filepath, data, function(err, res) {
                     // Catch errors, warn
                     if (err) {
-                        grunt.log.error(err);
-                        grunt.fail.warn('Failed to compile one of the source files.');
-                        grunt.log.writeln();
+                        grunt.log.error(err)
+                        grunt.fail.warn('Failed to compile one of the source files.')
+                        grunt.log.writeln()
 
                         // Prevent writing of failed to compile file, skip to next file
                         return
                     }
 
                     // Write rendered template to destination
-                    grunt.file.write(filedest, res);
+                    grunt.file.write(filedest, res)
 
                     // Debug process
-                    grunt.verbose.ok('File ' + chalk.cyan(filedest) + ' created.');
-                    grunt.verbose.writeln();
-                });
+                    grunt.verbose.ok('File ' + chalk.cyan(filedest) + ' created.')
+                    grunt.verbose.writeln()
+                })
 
                 countCompiled++
-            });
-        });
+            })
+        })
 
         // Log number of processed templates
-        var logType            = (countCompiled === totalFiles) ? 'ok' : 'error';
-        var countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red';
-        grunt.log[logType](chalk[countCompiledColor](countCompiled) + '/' + chalk.cyan(totalFiles) + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.');
+        var logType            = (countCompiled === totalFiles) ? 'ok' : 'error'
+        var countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red'
+        grunt.log[logType](chalk[countCompiledColor](countCompiled) + '/' + chalk.cyan(totalFiles) + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.')
 
         // Finish async task
-        completeTask();
-    });
-};
+        completeTask()
+    })
+}

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -42,6 +42,12 @@ module.exports = function(grunt) {
         this.files.forEach(function(file) {
             var filedest = file.dest;
 
+            if (!file.src.length) {
+                grunt.log.error('No source files specified for ' + filedest);
+
+                return
+            }
+
             file.src.forEach(function(src) {
                 var filepath = path.join(process.cwd(), src);
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -18,8 +18,14 @@ module.exports = function(grunt) {
         // Declare async task
         var completeTask = this.async();
 
-        // Get options
-        var options = this.options();
+        // Get options and set defaults
+        var options = this.options({
+            data                 : false,
+            tags                 : false,
+            paths                : '',
+            configureEnvironment : false,
+            preprocessData       : false
+        });
 
         // Finish task if no files specified
         if (!this.files.length) {
@@ -34,17 +40,11 @@ module.exports = function(grunt) {
             grunt.log.error('Template\'s data is empty. Guess you forget to specify data option');
         }
 
-        // Construct options for Nunjucks' environment
-        var envOptions = { watch: false };
-        if (options.tags) {
-            envOptions.tags = options.tags;
-        }
-
-        // Get path for Nunjucks' environment
-        var basePath = options.paths || '';
-
         // Arm Nunjucks
-        var env = nunjucks.configure(basePath, envOptions);
+        var env = nunjucks.configure(options.paths, {
+            watch: false,
+            tags: options.tags
+        });
 
         // Pass configuration to Nunjucks if specified
         if (typeof options.configureEnvironment === 'function') {

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -39,6 +39,9 @@ module.exports = function(grunt) {
             options.configureEnvironment.call(this, env, nunjucks);
         }
 
+        var totalFiles = this.files.length;
+        var countCompiled = 0;
+
         this.files.forEach(function(file) {
             var filedest = file.dest;
 
@@ -82,8 +85,12 @@ module.exports = function(grunt) {
                     grunt.verbose.ok('File "' + filedest + '" created.');
                     grunt.verbose.writeln();
                 });
+
+                countCompiled++
             });
         });
+
+        grunt.log.ok(countCompiled + '/' + totalFiles + ' ' + grunt.util.pluralize(totalFiles, 'file/files') + ' compiled.')
 
         completeTask();
     });

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -130,9 +130,9 @@ module.exports = function (grunt) {
                         // Debug process
                         grunt.verbose.ok('File ' + chalk.cyan(filedest) + ' created.')
                         grunt.verbose.writeln()
-                    })
 
-                    countCompiled++
+                        countCompiled++
+                    })
                 })
             })
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -17,6 +17,12 @@ module.exports = function(grunt) {
         var options = this.options();
         var completeTask = this.async();
 
+        if (!this.files.length) {
+            grunt.log.error('No files specified.');
+
+            return completeTask()
+        }
+
         if (!options.data) {
             grunt.log.error('Template`s data is empty. Guess you forget to specify data option');
         }

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -114,10 +114,10 @@ module.exports = function (grunt) {
 
                     // Asynchronously render templates with configurated Nunjucks environment
                     // and write to destination
-                    env.render(filepath, data, (err, res) => {
+                    env.render(filepath, data, (error, result) => {
                         // Catch errors, warn
-                        if (err) {
-                            grunt.log.error(err)
+                        if (error) {
+                            grunt.log.error(error)
                             grunt.fail.warn('Failed to compile one of the source files.')
                             grunt.log.writeln()
 
@@ -126,7 +126,7 @@ module.exports = function (grunt) {
                         }
 
                         // Write rendered template to destination
-                        grunt.file.write(filedest, res)
+                        grunt.file.write(filedest, result)
 
                         // Debug process
                         grunt.verbose.ok(`File ${chalk.cyan(filedest)} created.`)
@@ -142,10 +142,10 @@ module.exports = function (grunt) {
         })
 
         // Print any errors from rejects
-        .catch(err => {
-            if (err) {
+        .catch(error => {
+            if (error) {
                 grunt.log.writeln()
-                grunt.log.error(err)
+                grunt.log.error(error)
                 grunt.log.writeln()
             }
         })

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
 
         // Warn in case of undefined data
         if (!options.data) {
-            grunt.log.error(`Template's data is empty. Guess you've forget to specify data option`)
+            grunt.log.error(`Template's data is empty. Guess you've forget to specify data option.`)
         }
 
         // Arm Nunjucks
@@ -77,20 +77,20 @@ module.exports = function (grunt) {
 
                 // Check whether there are any source files
                 if (!file.src.length) {
-                    grunt.log.error(`No source files specified for ${chalk.cyan(filedest)}`)
+                    grunt.log.error(`No source files specified for ${chalk.cyan(filedest)}.`)
 
                     // Skip to next file — nothing we can do without specified source files
-                    return reject('For some destinations were not specified source files')
+                    return reject('For some destinations were not specified source files.')
                 }
 
                 // Iterate over files' sources
                 file.src.forEach(src => {
                     // Сheck whether source file exists
                     if (!grunt.file.exists(src)) {
-                        grunt.log.error(`Source file ${chalk.cyan(src)} for ${chalk.cyan(filedest)} not found`)
+                        grunt.log.error(`Source file ${chalk.cyan(src)} for ${chalk.cyan(filedest)} not found.`)
 
                         // Skip to next source file — nothing we can do with non-existing file
-                        return reject('Some source files were not found')
+                        return reject('Some source files were not found.')
                     }
 
                     // Construct absolute path to file for Nunjucks
@@ -122,7 +122,7 @@ module.exports = function (grunt) {
                             grunt.log.writeln()
 
                             // Prevent writing of failed to compile file, skip to next file
-                            return reject('Failed to compile some source files')
+                            return reject('Failed to compile some source files.')
                         }
 
                         // Write rendered template to destination

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -49,6 +49,12 @@ module.exports = function(grunt) {
             }
 
             file.src.forEach(function(src) {
+                if (!grunt.file.exists(src)) {
+                    grunt.log.error('Source file ' + src ' for ' + filedest + ' not found.');
+
+                    return
+                }
+
                 var filepath = path.join(process.cwd(), src);
 
                 // We need to clone the data

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var nunjucks = require('nunjucks');
+var chalk = require('chalk');
 var path = require('path');
 
 module.exports = function(grunt) {
@@ -46,14 +47,14 @@ module.exports = function(grunt) {
             var filedest = file.dest;
 
             if (!file.src.length) {
-                grunt.log.error('No source files specified for ' + filedest);
+                grunt.log.error('No source files specified for ' + chalk.cyan(filedest));
 
                 return
             }
 
             file.src.forEach(function(src) {
                 if (!grunt.file.exists(src)) {
-                    grunt.log.error('Source file ' + src + ' for ' + filedest + ' not found.');
+                    grunt.log.error('Source file ' + chalk.cyan(src) + ' for ' + chalk.cyan(filedest) + ' not found.');
 
                     return
                 }
@@ -82,7 +83,7 @@ module.exports = function(grunt) {
                     }
                     grunt.file.write(filedest, res);
 
-                    grunt.verbose.ok('File "' + filedest + '" created.');
+                    grunt.verbose.ok('File "' + chalk.cyan(filedest) + '" created.');
                     grunt.verbose.writeln();
                 });
 

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -12,9 +12,9 @@ var nunjucks = require('nunjucks')
 var chalk = require('chalk')
 var path = require('path')
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
-    grunt.registerMultiTask('nunjucks', 'Renders nunjucks\' template to HTML', function() {
+    grunt.registerMultiTask('nunjucks', 'Renders nunjucks\' template to HTML', function () {
         // Declare async task
         var completeTask = this.async()
 
@@ -68,7 +68,7 @@ module.exports = function(grunt) {
         var countCompiled = 0
 
         // Iterate over all files' groups
-        this.files.forEach(function(file) {
+        this.files.forEach(function (file) {
             // Set destination
             var filedest = file.dest
 
@@ -81,7 +81,7 @@ module.exports = function(grunt) {
             }
 
             // Iterate over files' sources
-            file.src.forEach(function(src) {
+            file.src.forEach(function (src) {
                 // Сheck whether source file exists
                 if (!grunt.file.exists(src)) {
                     grunt.log.error('Source file ' + chalk.cyan(src) + ' for ' + chalk.cyan(filedest) + ' not found.')
@@ -111,7 +111,7 @@ module.exports = function(grunt) {
 
                 // Asynchronously render templates with configurated Nunjucks environment
                 // and write to destination
-                env.render(filepath, data, function(err, res) {
+                env.render(filepath, data, function (err, res) {
                     // Catch errors, warn
                     if (err) {
                         grunt.log.error(err)

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -67,12 +67,10 @@ module.exports = function (grunt) {
         // Start counter for number of compiled files
         var countCompiled = 0
 
-        var self = this
-
-        new Promise(function (resolve, reject) {
+        new Promise((resolve, reject) => {
 
             // Iterate over all files' groups
-            self.files.forEach(function (file) {
+            this.files.forEach(file => {
                 // Set destination
                 var filedest = file.dest
 
@@ -85,7 +83,7 @@ module.exports = function (grunt) {
                 }
 
                 // Iterate over files' sources
-                file.src.forEach(function (src) {
+                file.src.forEach(src => {
                     // Сheck whether source file exists
                     if (!grunt.file.exists(src)) {
                         grunt.log.error('Source file ' + chalk.cyan(src) + ' for ' + chalk.cyan(filedest) + ' not found.')
@@ -115,7 +113,7 @@ module.exports = function (grunt) {
 
                     // Asynchronously render templates with configurated Nunjucks environment
                     // and write to destination
-                    env.render(filepath, data, function (err, res) {
+                    env.render(filepath, data, (err, res) => {
                         // Catch errors, warn
                         if (err) {
                             grunt.log.error(err)
@@ -143,7 +141,7 @@ module.exports = function (grunt) {
         })
 
         // Print any errors from rejects
-        .catch(function (err) {
+        .catch(err => {
             if (err) {
                 grunt.log.writeln()
                 grunt.log.error(err)
@@ -152,7 +150,7 @@ module.exports = function (grunt) {
         })
 
         // Log number of processed templates
-        .then(function () {
+        .then(() => {
             // Log number of processed templates
             var logType            = (countCompiled === totalFiles) ? 'ok' : 'error'
             var countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red'

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -22,12 +22,6 @@ module.exports = function (grunt) {
         // @note We're using `undefined` to fallback to Nunjucks' default settings
         const options = this.options({
             paths                : '',
-            autoescape           : undefined,
-            throwOnUndefined     : undefined,
-            trimBlocks           : undefined,
-            lstripBlocks         : undefined,
-            noCache              : undefined,
-            tags                 : undefined,
             configureEnvironment : false,
             data                 : false,
             preprocessData       : false

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -151,7 +151,7 @@ module.exports = function (grunt) {
         })
 
         // Log number of processed templates
-        .then(() => {
+        .then(success => {
             // Log number of processed templates
             let logType            = (countCompiled === totalFiles) ? 'ok' : 'error'
             let countCompiledColor = (countCompiled === totalFiles) ? 'green' : 'red'


### PR DESCRIPTION
Main purposes of that PR:

* Drop `async` in favor of native methods. See details in commit message
* Better error detection and handling
* `Chalk` for nicer messages
* Be verbose only in `--verbose` mode, otherwise just print number of compiled templates
* Better declaration of default options
* Add full configuration of Nunjucks' environment
* Time async beast with `Promise()`
* Move to ES6
  * Drop semicolons
  * Arrow functions
  * `let` and `const` instead of `var`
  * Templates for messages instead of concatenation
* Other minor improvements
* Documentation

All changes are backward-compatible.

Sorry for dumping a lot of changes into single PR. Otherwise it would take a lot of time to publish all features.

In case we'll decide to not implement somethings, I always can cherry pick necessary commits into another PR.

This PR will bump minimal Node version to `0.12.0` (since we need `Promise()`), and later minimal version will be bumped to actual stable version `4.0.0` for ES6 features.

All commits are pretty much self explaining, some of them have details on 2nd line.

Please, check comments and messages for typos and just bad English.

Thanks in advance!