### PR TITLE
Fix minimal required engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "compile"
   ],
   "engines": {
-    "node": "^4.0.0"
+    "node": ">=4.0.0"
   },
   "dependencies": {
     "chalk": "^1.1.1",


### PR DESCRIPTION
Fix minimal required engine version to accept Node 4.0.0 and higher, since caret won't accept change in major version (in other words, 5.0.0 will result in warning about not matching version).