### PR TITLE
Update to nunjucks 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-nunjucks-2-html",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Grunt task for rendering nunjucks` templates to HTML",
   "homepage": "https://github.com/vitkarpov/grunt-nunjucks-2-html",
   "author": "Viktor Karpov <viktor.s.karpov@gmail.com>",
@@ -22,12 +22,13 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "nunjucks": ">= 2.3.0"
+    "nunjucks": ">= 2.4.2"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
+    "grunt-jscs": "^2.8.0",
     "standard": "^5.3.1"
   },
   "scripts": {


### PR DESCRIPTION
@vitkarpov I updated to the latest version of nunjucks.
I also added `grunt-jscs` as a dev dependency (I received an error that grunt-jscs could not be found when I ran `grunt test` locally).

All tests are passing for me locally.