### PR TITLE
Fixed semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-nunjucks-2-html",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Grunt task for rendering nunjucks` templates to HTML",
   "homepage": "https://github.com/vitkarpov/grunt-nunjucks-2-html",
   "author": "Viktor Karpov <viktor.s.karpov@gmail.com>",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "nunjucks": "^2.5.2"
+    "nunjucks": "^3.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-nunjucks-2-html",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Grunt task for rendering nunjucks` templates to HTML",
   "homepage": "https://github.com/vitkarpov/grunt-nunjucks-2-html",
   "author": "Viktor Karpov <viktor.s.karpov@gmail.com>",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.1",
-    "nunjucks": ">= 2.4.2"
+    "nunjucks": "^2.5.2"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",


### PR DESCRIPTION
Users should be able to switch to a different major version of *nunjucks* or any other dependencies and beeing able to lock on that specific version.
Said that using of '>=' is not permitted by semver and should be replaced with '^'.
Any major update of dependencies should be referenced as separated commit to this plugin and increment its version.

read: http://semver.org/