### PR TITLE
Pass options to Nunjucks directly

### DIFF
--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -18,7 +18,6 @@ module.exports = function (grunt) {
     const completeTask = this.async()
 
     // Get options and set defaults
-    // @note We're using `undefined` to fallback to Nunjucks' default settings
     const options = this.options({
       watch: false,
       paths: '',

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -20,10 +20,12 @@ module.exports = function (grunt) {
     // Get options and set defaults
     // @note We're using `undefined` to fallback to Nunjucks' default settings
     const options = this.options({
+      watch: false,
       paths: '',
       configureEnvironment: false,
       data: false,
-      preprocessData: false
+      preprocessData: false,
+      noCache: true
     })
 
     // Finish task if no files specified
@@ -40,15 +42,7 @@ module.exports = function (grunt) {
     }
 
     // Arm Nunjucks
-    const env = nunjucks.configure(options.paths, {
-      watch: false,
-      autoescape: options.autoescape,
-      throwOnUndefined: options.throwOnUndefined,
-      trimBlocks: options.trimBlocks,
-      lstripBlocks: options.lstripBlocks,
-      noCache: true,
-      tags: options.tags
-    })
+    const env = nunjucks.configure(options.paths, options)
 
     // Pass configuration to Nunjucks if specified
     if (typeof options.configureEnvironment === 'function') {


### PR DESCRIPTION
There is no reason to cherry pick only certain options which will be passed from `this.options()` to `nunjucks.configure()`.

Instead, we can brutally pass all options directly to `nunjucks.configure()`. Yes, sometimes it will also pass not relevant to `nunjucks` options like `configureEnvironment` and so on, but since Nunjucks doesn't know anything about them, they will be simply ignored.

This change will allows us to rest assured that users will be always able to pass environment configurations to Nunjucks, no matter what API changes will happen in Nunjucks.

Also, it will allow users to change options they wanted to change. For instance, right now we've hardcoded `noChache: true` and users wasn't able to enable cache whenever they needed it.