### PR TITLE
Standard maintainance

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,12 +2,6 @@ var path = require('path')
 
 module.exports = function (grunt) {
   grunt.initConfig({
-    jscs: {
-      src: ['tasks/nunjucks.js', 'tests/**/*.js'],
-      options: {
-        config: '.jscsrc'
-      }
-    },
     nunjucks: {
       options: {
         fooName: 'foo',
@@ -32,7 +26,6 @@ module.exports = function (grunt) {
     }
   })
 
-  grunt.loadNpmTasks('grunt-jscs')
   grunt.loadTasks('tasks/')
 
   grunt.registerTask('test', ['nunjucks'])

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "babel-eslint": "^4.1.3",
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
+    "snazzy": "^7.0.0",
     "standard": "^10.0.2"
   },
   "scripts": {
-    "test": "standard && grunt test && node tests/all.js"
+    "test": "standard | snazzy && grunt test && node tests/all.js"
   },
   "standard": {
     "parser": "babel-eslint"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "standard": "^5.3.1"
   },
   "scripts": {
-    "test": "node_modules/standard/bin/cmd.js && grunt test && node tests/all.js"
+    "test": "standard && grunt test && node tests/all.js"
   },
   "standard": {
     "parser": "babel-eslint"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-eslint": "^4.1.3",
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
-    "standard": "^5.3.1"
+    "standard": "^10.0.2"
   },
   "scripts": {
     "test": "standard && grunt test && node tests/all.js"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "nunjucks": "^3.0.0"
   },
   "devDependencies": {
-    "babel-eslint": "^4.1.3",
+    "babel-eslint": "^7.2.3",
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
     "snazzy": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "babel-eslint": "^7.2.3",
     "expect.js": "^0.3.1",
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.1",
     "snazzy": "^7.0.0",
     "standard": "^10.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "babel-eslint": "^4.1.3",
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
-    "grunt-jscs": "^2.8.0",
     "standard": "^5.3.1"
   },
   "scripts": {

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -65,7 +65,7 @@ module.exports = function (grunt) {
           grunt.log.error(`No source files specified for ${chalk.cyan(filedest)}.`)
 
           // Skip to next file — nothing we can do without specified source files
-          return reject('For some destinations were not specified source files.')
+          return reject(new Error('For some destinations were not specified source files.'))
         }
 
         // Iterate over files' sources
@@ -96,7 +96,7 @@ module.exports = function (grunt) {
               grunt.log.writeln()
 
               // Prevent writing of failed to compile file, skip to next file
-              return reject('Failed to compile some source files.')
+              return reject(new Error('Failed to compile some source files.'))
             }
 
             // Write rendered template to destination


### PR DESCRIPTION
Since I'm on it anyway, here is some additional love to Standard and tests.

`grunt-jscs` removed, since JSCS has been merged into ESLint, which is used by Standard, so there is no point in continue using it.