### PR TITLE
Refactor rendering handling

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,8 +13,8 @@ module.exports = function (grunt) {
         configureEnvironment: function (env) {
           var options = this.options()
           env.addGlobal(options.fooName, 'bar')
-          env.addFilter('timeout', ({ message, delay }, done) =>
-            setTimeout(() => done(null, message), delay)
+          env.addFilter('timeout', (options, done) =>
+            setTimeout(() => done(null, options.message), options.delay)
           , true)
         }
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,9 @@ module.exports = function (grunt) {
         configureEnvironment: function (env) {
           var options = this.options()
           env.addGlobal(options.fooName, 'bar')
+          env.addFilter('timeout', ({ message, delay }, done) =>
+            setTimeout(() => done(null, message), delay)
+          , true)
         }
       },
       render: {
@@ -20,7 +23,9 @@ module.exports = function (grunt) {
           'tests/base/_output.html': ['tests/base/input.html'],
           'tests/autoescape/_output.html': ['tests/autoescape/input.html'],
           'tests/leaking-vars/_output1.html': ['tests/leaking-vars/input1.html'],
-          'tests/leaking-vars/_output2.html': ['tests/leaking-vars/input2.html']
+          'tests/leaking-vars/_output2.html': ['tests/leaking-vars/input2.html'],
+          'tests/async/_output1.html': ['tests/async/input1.html'],
+          'tests/async/_output2.html': ['tests/async/input2.html']
         }
       }
     }

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -12,10 +12,42 @@ const nunjucks = require('nunjucks')
 const chalk = require('chalk')
 const path = require('path')
 
+/**
+ * Promsify Nunjucks render
+ * @param {object} env    Nunjucks configured environment
+ * @param {string} src    Path to the template
+ * @param {object} [data] Template context
+ * @return {promise}
+ */
+const render = (env, src, data) => new Promise((resolve, reject) => {
+  env.render(src, data, (error, rendered) => {
+    if (error) return reject(error)
+    return resolve(rendered)
+  })
+})
+
+/**
+ * Prepare data by cloning it to avoid leaks and processing it
+ * through relevant function
+ * @param {object}   options                  Task options
+ * @param {object}   [options.data]           Template context
+ * @param {function} [options.preprocessData] Processor for context
+ * @param {object}   file                     Current `this.files` `file` instance
+ * @return {object} Prepared data
+ */
+const prepareData = (options, file) => {
+  let data = Object.assign({}, options.data)
+
+  if (options.data && typeof options.preprocessData === 'function') {
+    data = options.preprocessData.call(file, data)
+  }
+
+  return data
+}
+
 module.exports = function (grunt) {
   grunt.registerMultiTask('nunjucks', `Renders Nunjucks' templates to HTML`, function () {
-    // Declare async task
-    const completeTask = this.async()
+    const done = this.async()
 
     // Get options and set defaults
     const options = this.options({
@@ -27,112 +59,67 @@ module.exports = function (grunt) {
       noCache: true
     })
 
-    // Finish task if no files specified
-    if (!this.files.length) {
-      grunt.log.error('No files specified.')
+    const total = this.files.length
 
-      // Finish task — nothing we can do without specified files
-      return completeTask()
+    if (!total) {
+      grunt.log.error('No files specified.')
+      return done()
     }
 
-    // Warn in case of undefined data
     if (!options.data) {
       grunt.log.error(`Template's data is empty. Guess you've forget to specify data option.`)
     }
 
-    // Arm Nunjucks
     const env = nunjucks.configure(options.paths, options)
 
-    // Pass configuration to Nunjucks if specified
     if (typeof options.configureEnvironment === 'function') {
       options.configureEnvironment.call(this, env, nunjucks)
     }
 
-    // Get number of files
-    const totalFiles = this.files.length
-    // Start counter for number of compiled files
-    let countCompiled = 0
+    let success = 0
+    let errors = 0
 
-    // Run compilation asynchronously, wait for finish, then print results and complete task
-    const task = new Promise((resolve, reject) => {
-      // Iterate over all files' groups
-      this.files.forEach(file => {
-        // Set destination
-        let filedest = file.dest
+    const renderFiles = this.files.reduce((files, file) => {
+      let filedest = file.dest
 
-        // Check whether there are any source files
-        if (!file.src.length) {
-          grunt.log.error(`No source files specified for ${chalk.cyan(filedest)}.`)
-
-          // Skip to next file — nothing we can do without specified source files
-          return reject(new Error('For some destinations were not specified source files.'))
-        }
-
-        // Iterate over files' sources
-        file.src.forEach(src => {
-          // Construct absolute path to file for Nunjucks
-          let filepath = path.join(process.cwd(), src)
-
-          let data = {}
-          // Clone data
-          for (let i in options.data) {
-            if (options.data.hasOwnProperty(i)) {
-              data[i] = options.data[i]
-            }
-          }
-
-          // Preprocess data
-          if (options.data && typeof options.preprocessData === 'function') {
-            data = options.preprocessData.call(file, data)
-          }
-
-          // Asynchronously render templates with configurated Nunjucks environment
-          // and write to destination
-          env.render(filepath, data, (error, result) => {
-            // Catch errors, warn
-            if (error) {
-              grunt.log.error(error)
-              grunt.fail.warn('Failed to compile one of the source files.')
-              grunt.log.writeln()
-
-              // Prevent writing of failed to compile file, skip to next file
-              return reject(new Error('Failed to compile some source files.'))
-            }
-
-            // Write rendered template to destination
-            grunt.file.write(filedest, result)
-
-            // Debug process
-            grunt.verbose.ok(`File ${chalk.cyan(filedest)} created.`)
-            grunt.verbose.writeln()
-
-            countCompiled++
-          })
-        })
-      })
-
-      // Finish Promise
-      resolve()
-    })
-
-    // Print any errors from rejects
-    task.catch(error => {
-      if (error) {
-        grunt.log.writeln()
-        grunt.log.error(error)
-        grunt.log.writeln()
+      if (!filedest) {
+        grunt.log.error(`No dest file specified`)
+        done()
       }
-    })
 
-    // Log number of processed templates
-    task.then(success => {
-      // Log number of processed templates
-      let logType = (countCompiled === totalFiles) ? 'ok' : 'error'
-      let countCompiledColor = (logType === 'ok') ? 'green' : 'red'
-      grunt.log[logType](`${chalk[countCompiledColor](countCompiled)}/${chalk.cyan(totalFiles)} ${grunt.util.pluralize(totalFiles, 'file/files')} compiled.`)
-    })
+      if (!file.src || !file.src.length) {
+        grunt.log.error(`No source files specified for ${chalk.cyan(filedest)}.`)
+        done()
+      }
 
-    // Finish async task
-    completeTask()
+      const renders = file.src.map((src) => new Promise((resolve, reject) =>
+        render(env, path.resolve(src), prepareData(options, file))
+          .then((rendered) => {
+            grunt.file.write(filedest, rendered)
+            success++
+          })
+          .catch((error) => {
+            grunt.log.error(error)
+            errors++
+          })
+          .then(() => resolve())
+      ))
+
+      return files.concat(renders)
+    }, [])
+
+    Promise.all(renderFiles)
+      .then(() => {
+        const isWrong = success !== total
+        const logColor = isWrong ? 'error' : 'ok'
+        const totalColor = isWrong ? 'red' : 'green'
+
+        grunt.log[logColor](`${chalk[totalColor](success)}/${chalk.cyan(total)} files rendered`)
+
+        if (isWrong) throw new Error(`Failed to compile ${errors} ${grunt.util.pluralize(errors, 'file/files')}.\nSee log above for details.`)
+
+        done()
+      })
+      .catch((error) => done(error))
   })
 }

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -92,7 +92,7 @@ module.exports = function (grunt) {
         done()
       }
 
-      const renders = file.src.map((src) => new Promise((resolve, reject) =>
+      const renders = file.src.map((src) =>
         render(env, path.resolve(src), prepareData(options, file))
           .then((rendered) => {
             grunt.file.write(filedest, rendered)
@@ -102,8 +102,7 @@ module.exports = function (grunt) {
             grunt.log.error(error)
             errors++
           })
-          .then(() => resolve())
-      ))
+      )
 
       return files.concat(renders)
     }, [])

--- a/tests/all.js
+++ b/tests/all.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const tests = ['base', 'leaking-vars', 'autoescape']
+const tests = ['base', 'leaking-vars', 'autoescape', 'async']
 
 tests.forEach(function (folder) {
   require(path.join(__dirname, folder))()

--- a/tests/async/index.js
+++ b/tests/async/index.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const expect = require('expect.js')
+const fs = require('fs')
+const util = require('util')
+const path = require('path')
+
+let expected = [
+  fs.readFileSync(path.join(__dirname, 'output1.html')).toString(),
+  fs.readFileSync(path.join(__dirname, 'output2.html')).toString()
+]
+
+let generated = [
+  fs.readFileSync(path.join(__dirname, '_output1.html')).toString(),
+  fs.readFileSync(path.join(__dirname, '_output2.html')).toString()
+]
+
+module.exports = function () {
+  expected.forEach((input, i) => {
+    try {
+      expect(input).to.eql(generated[i])
+    } catch (e) {
+      console.log(util.inspect(e, {colors: true}))
+    }
+  })
+}

--- a/tests/async/input1.html
+++ b/tests/async/input1.html
@@ -1,0 +1,4 @@
+<div>
+    {{ { message: 'Async timeout message 250ms', delay: 250 }|timeout() }}
+    {{ { message: 'Async timeout message 100ms', delay: 100 }|timeout() }}
+</div>

--- a/tests/async/input2.html
+++ b/tests/async/input2.html
@@ -1,0 +1,1 @@
+<div>Static</div>

--- a/tests/async/output1.html
+++ b/tests/async/output1.html
@@ -1,0 +1,4 @@
+<div>
+    Async timeout message 250ms
+    Async timeout message 100ms
+</div>

--- a/tests/async/output2.html
+++ b/tests/async/output2.html
@@ -1,0 +1,1 @@
+<div>Static</div>


### PR DESCRIPTION
Hi

I've encountered issues while building async filter when using grunt-nunjucks-2-html. Turned out, they are related to the way how we use Promises.

I've already noticed before some quirks with wrong messages like 4/5 files rendered, but not producing any actual errors. I could never figure out where they were coming from.

Finally, figured out how to fix it.

* Fixed issue with race conditions caused by templates with async filters (and most likely with async loaders).

   Task finished before async templates actually were rendered.

* Improved error handling

   The task will properly count and display successfully rendered and errored templates and fail if there were any errors.

   Note, that right now task will try to render _all_ templates, even with errors, and fail task only in the end if there were any errors during rendering. It was intentional behavior since it allows to see all errors of templates during a single run, though it might be annoying in large projects. Maybe we need to handle it with an option.

* Simplified code

This is PR for 2.x branch, but if it's ok it can be easily adapted for master branch.